### PR TITLE
voegt een print event handler toe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,6 +699,7 @@
 										<include>**/OverviewMap.js</include>
 										<include>**/Viewer.js</include>
 										<include>**/ZoekFormulier.js</include>
+										<include>**/PrintEventHandler.js</include>
 									</includes>
 									<output>${project.build.directory}/${project.build.finalName}/js/cbsviewer.js</output>
 									<removeIncluded>true</removeIncluded>

--- a/src/main/js/PrintEventHandler.js
+++ b/src/main/js/PrintEventHandler.js
@@ -1,0 +1,31 @@
+/**
+ * Handle browser print events.
+ * 
+ * @todo browser print events zijn buggy.
+ * @author PrinsMC
+ * 
+ */
+(function() {
+	var beforePrint = function() {
+		//Functionality to run before printing
+		Viewer.printPrepare();
+	};
+	var afterPrint = function() {
+		//Functionality to run after printing
+		// Viewer.toggleFullSize();
+	};
+
+	if (window.matchMedia) {
+		var mediaQueryList = window.matchMedia('print');
+		mediaQueryList.addListener(function(mql) {
+			if (mql.matches) {
+				beforePrint();
+			} else {
+				afterPrint();
+			}
+		});
+	}
+
+	window.onbeforeprint = beforePrint;
+	window.onafterprint  = afterPrint;
+}());


### PR DESCRIPTION
hoewel buggy in veel browsers, dus misschien niet gebruiken..

Het lijkt erop dat de implementatie van onbeforeprint en/of css media
switch dermate onbetrouwbaar is dat dit niet de manier is..

In dat
geval oplossen door de gebruiker te vertellen dat de kaart eerst even
verkleind moet worden om deze print-klaar te maken.

zie: #4
